### PR TITLE
Update NED downloads to come from an Amazon S3 bucket

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,5 @@ numpy>=1.14.0
 pandas>=0.22.0
 refet>=0.3.7
 requests>=2.2.0
+requests-html>=0.10.0
 scipy>=1.0.0

--- a/tools/download/_utils.py
+++ b/tools/download/_utils.py
@@ -4,6 +4,7 @@ from ftplib import FTP
 import logging
 
 import requests
+from requests_html import HTMLSession
 
 
 def ftp_download(site_url, site_folder, file_name, output_path):
@@ -34,6 +35,14 @@ def ftp_file_list(site_url, site_folder):
         logging.info('  Unhandled exception: {}'.format(e))
         files = []
     return files
+
+
+def html_link_list(url):
+    """List all links at the url."""
+    session = HTMLSession()
+    r = session.get(url)
+    r.html.render(timeout=10, sleep=10)
+    return list(r.html.links)
 
 
 def url_download(download_url, output_path, verify=True):


### PR DESCRIPTION
The downloads from the FTP server are reliably corrupt for certain tiles.  The Amazon S3 bucket appears more reliable.

fixes #69 

